### PR TITLE
change loss function from binary cross entropy to 'normal' cross entropy

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,7 @@ model = nn.Sequential(
     nn.Linear(16, 3),
     nn.Sigmoid())
 
-loss_fn = nn.BCELoss()  # binary cross entropy
+loss_fn = nn.CrossEntropyLoss()  # cross entropy
 optimizer = optim.Adam(model.parameters(), lr=0.0001)  # Adam optimizer
 
 batch_size = 100


### PR DESCRIPTION
BCE macht nur Sinn wenn man zwei Klassen als Target verwendet oder? Also "normale" Cross Entropy für mehr als 2 Klassen?

["It is useful when training a classification problem with C classes."](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html)

Der output war doch:
- weiß gewinnt
- schwarz gewinnt
- draw
oder?